### PR TITLE
Pbzip2

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -26,7 +26,7 @@ process tar {
 
 	script:
 	"""
-	module load pbzip2/1.1.13
+	module load $PBZIP2_MODULE
 	tar -c ${run_dir_path} | pbzip2 -c -p${SLURM_CPUS_PER_TASK} -m2000 > ${run_dir_name}.tar.bz2 
 	"""
 }

--- a/main.nf
+++ b/main.nf
@@ -26,7 +26,8 @@ process tar {
 
 	script:
 	"""
-	tar cvjf ${run_dir_name}.tar.bz2 ${run_dir_path}
+	module load pbzip2/1.1.13
+	tar -c ${run_dir_path} | pbzip2 -c -p${SLURM_CPUS_PER_TASK} -m2000 > ${run_dir_name}.tar.bz2 
 	"""
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,7 @@ env.PICARD_MODULE = "picard/2.23.8"
 env.PYTHON_MODULE = "interop/python3.6/1.1.4"
 env.PHENIQS_MODULE = "pheniqs/1.1.0"
 env.JDK_MODULE = "jdk/1.8.0_271"
+env.PBZIP2 = "pbzip2/1.1.13"
 
 // nextflow work dir
 workDir = ""

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,4 +30,8 @@ process {
     time = { 2.h * task.attempt }
     errorStrategy = 'retry'
     maxRetries = 3
+    withName: tar {
+	    cpus = 6
+        memory = 4.GB
+    }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,7 @@ env.PICARD_MODULE = "picard/2.23.8"
 env.PYTHON_MODULE = "interop/python3.6/1.1.4"
 env.PHENIQS_MODULE = "pheniqs/1.1.0"
 env.JDK_MODULE = "jdk/1.8.0_271"
-env.PBZIP2 = "pbzip2/1.1.13"
+env.PBZIP2_MODULE = "pbzip2/1.1.13"
 
 // nextflow work dir
 workDir = ""

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,7 +31,7 @@ process {
     errorStrategy = 'retry'
     maxRetries = 3
     withName: tar {
-	    cpus = 6
+	cpus = 6
         memory = 4.GB
     }
 }


### PR DESCRIPTION
Using pbzip2 over bzip2 increases speeds of compression around 10x.

Comparison
https://docs.google.com/spreadsheets/d/102avqlAww5_cJoJ5BI5HKaQielPP5CAn-hwdUkepLPM/edit#gid=0

Since bzip2 only uses 1 CPU, the number of resources given will have no impact.  Suggest we keep this process at 6CPU and the maximum memory used by pbzip2 is 2000MB so request 4GB. 